### PR TITLE
Enable per-fan sensor rules

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,14 +31,27 @@ ESP_IP        = "192.168.1.41"           # при необходимости п�
 FAN_COUNT     = 8
 CONNECT_TO    = 2.0                     # s   connect timeout
 READ_TO       = 3.0                     # s   read timeout
+MONITOR_URL   = "http://localhost:8085/data.json"  # OHM JSON URL
+TEMP_POLL_INTERVAL = 2.0               # s
+TARGETS = ["Core Average", "GPU Core"]
 
 STATIC_DIR.mkdir(exist_ok=True)
 
 # ────────────────── persistent configuration ──────────────────
+_default_rule = {
+    "sensors": [],
+    "tmin": 30,
+    "tmax": 70,
+    "pwm_min": 0,
+    "pwm_max": 255,
+    "mode": "max",
+}
+
 _default_cfg = {
     "labels": [f"Fan {i}" for i in range(FAN_COUNT)],
     "presets": {},                          # name → [8 pwm]
-    "layout": [{"x": 10+i*10, "y": 50} for i in range(FAN_COUNT)]
+    "layout": [{"x": 10+i*10, "y": 50} for i in range(FAN_COUNT)],
+    "rules": [_default_rule.copy() for _ in range(FAN_COUNT)],
 }
 try:
     config: Dict = {**_default_cfg, **json.loads(CONFIG_FILE.read_text())}
@@ -60,9 +73,12 @@ _client = httpx.AsyncClient(
     limits=httpx.Limits(max_keepalive_connections=8, max_connections=16)
 )
 
+_mon_client = httpx.AsyncClient(timeout=5.0)
+
 @app.on_event("shutdown")
 async def _close():
     await _client.aclose()
+    await _mon_client.aclose()
 
 # ───────────────── helpers к ESP32 ────────────────────────────
 async def esp_get(path: str):
@@ -87,6 +103,27 @@ async def esp_post_json(path: str, data):
     except httpx.RequestError as exc:
         raise HTTPException(status.HTTP_502_BAD_GATEWAY, f"ESP error: {exc!s}")
 
+# ─────────────── temperature monitor helpers ───────────────
+async def fetch_hwmon_data():
+    try:
+        r = await _mon_client.get(MONITOR_URL)
+        r.raise_for_status()
+        return r.json()
+    except Exception:
+        return None
+
+def find_temperatures(tree, targets):
+    out = {}
+    if isinstance(tree, dict):
+        if tree.get("Type") == "Temperature" and tree.get("Text") in targets:
+            out[tree["Text"]] = tree.get("Value")
+        for ch in tree.get("Children", []):
+            out.update(find_temperatures(ch, targets))
+    elif isinstance(tree, list):
+        for node in tree:
+            out.update(find_temperatures(node, targets))
+    return out
+
 # ─────────────── in-memory зеркало состояния ─────────────────
 class FanState(BaseModel):
     pwm: int = Field(255, ge=0, le=255)
@@ -99,6 +136,8 @@ class SysInfo(BaseModel):
 
 state: List[FanState] = [FanState() for _ in range(FAN_COUNT)]
 info  = SysInfo()
+rules: List[Dict] = config.get("rules", [_default_rule.copy() for _ in range(FAN_COUNT)])
+temp_sources: List[str] = TARGETS.copy()
 
 # ────────────────────────── API models ────────────────────────
 class SetReq(BaseModel):
@@ -201,6 +240,64 @@ async def set_layout(req: LayoutReq):
             raise HTTPException(400,"Positions must be 0-100 %")
     config["layout"] = req.layout
     save_cfg()
+
+# ─────────────────────────── rules / temps ────────────────────
+@app.get("/temp_sources")
+async def get_sources():
+    return temp_sources
+
+@app.get("/rules")
+async def get_rules():
+    return rules
+
+@app.post("/rules", status_code=204)
+async def set_rules(new_rules: List[Dict]):
+    if len(new_rules) != FAN_COUNT:
+        raise HTTPException(400, "Array of rules for each fan expected")
+    for r in new_rules:
+        if not isinstance(r.get("sensors", []), list):
+            r["sensors"] = []
+        r.setdefault("tmin", 30)
+        r.setdefault("tmax", 70)
+        r.setdefault("pwm_min", 0)
+        r.setdefault("pwm_max", 255)
+        r.setdefault("mode", "max")
+    global rules
+    rules = new_rules
+    config["rules"] = rules
+    save_cfg()
+
+async def auto_loop():
+    while True:
+        data = await fetch_hwmon_data()
+        if data:
+            temps = find_temperatures(data, TARGETS)
+            for i, r in enumerate(rules):
+                if not r.get("sensors"):
+                    continue
+                vals = [temps.get(s) for s in r["sensors"] if temps.get(s) is not None]
+                if not vals:
+                    continue
+                t = max(vals) if r.get("mode") == "max" else sum(vals)/len(vals)
+                if t <= r["tmin"]:
+                    pwm = r["pwm_min"]
+                elif t >= r["tmax"]:
+                    pwm = r["pwm_max"]
+                else:
+                    k = (t - r["tmin"]) / (r["tmax"] - r["tmin"])
+                    pwm = int(r["pwm_min"] + (r["pwm_max"] - r["pwm_min"]) * k)
+                pwm = max(0, min(255, int(pwm)))
+                if pwm != state[i].pwm:
+                    state[i].pwm = pwm
+                    try:
+                        await esp_get(f"/set?fan={i}&pwm={pwm}")
+                    except Exception:
+                        pass
+        await asyncio.sleep(TEMP_POLL_INTERVAL)
+
+@app.on_event("startup")
+async def start_loop():
+    asyncio.create_task(auto_loop())
 
 # ─────────────────────────── UI  ──────────────────────────────
 HTML = r"""<!DOCTYPE html>
@@ -444,7 +541,7 @@ async function editLabels(){
 
 @app.get("/", response_class=HTMLResponse)
 async def root():
-    return HTML
+    return (STATIC_DIR / "index.html").read_text(encoding="utf-8")
 
 # ───────────────────────── CLI ────────────────────────────────
 if __name__=="__main__":

--- a/static/index.html
+++ b/static/index.html
@@ -26,7 +26,7 @@
       <div id="cfgBox">
         <div class="cfgRow">
           <label>Boost (s)</label>
-          <input id="boost" type="number" min="0" max="300">
+          <input id="boostSec" type="number" min="0" max="300">
           <button id="boostSave">Save</button>
         </div>
         <div class="cfgRow">
@@ -53,6 +53,8 @@
   <div id="rulesTable"></div>
   <button id="saveRulesBtn" style="margin-top:8px">Save Rules</button>
 </div>
+
+<script src="/static/main.js"></script>
 
 <script>
 /* ─────────────── RULES UI ─────────────── */
@@ -126,8 +128,7 @@ loadRules();
 
       </div>
     </aside>
-  </section>
+</section>
 </main>
-<script src="/static/main.js"></script>
 </body>
 </html>

--- a/static/main.js
+++ b/static/main.js
@@ -1,0 +1,159 @@
+/* ─────────────── GLOBALS ─────────────── */
+const N = 8;
+let q = {}, timer;
+let labels = [], presets = {}, layout = [];
+let editMode = false, dragEl = null, offX = 0, offY = 0;
+const $ = id => document.getElementById(id);
+
+/* ─────────────── UTILS ─────────────── */
+function pwmToDur(p){ if(!p) return '0s';
+  const min=0.4,max=4, d=max-(p/255)*(max-min); return d.toFixed(2)+'s'; }
+function applyPWM(i,p){
+  $("v"+i).textContent=p; $("r"+i).value=p;
+  const ic=$("f"+i);
+  if(p===0){ic.classList.remove('spin');ic.style.animation='none';}
+  else{ic.classList.add('spin');ic.style.animationDuration=pwmToDur(p);}
+}
+function sendBulk(){
+  const arr=[...Array(N)].map((_,i)=>+$("r"+i).value);
+  fetch('/bulk',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(arr)});
+}
+
+/* ─────────────── BUILD UI ─────────────── */
+function build(){
+  // sliders
+  const sliders=$("sliders");
+  const svg=`<svg viewBox="0 0 100 100">
+  <g fill="none" stroke="currentColor" stroke-width="8">
+   <circle cx="50" cy="50" r="14"/>
+   <path d="M50 5 l6 25 a22 22 0 0 1-12 0z"/>
+   <path d="M95 50 l-25 6 a22 22 0 0 1 0-12z"/>
+   <path d="M50 95 l-6-25 a22 22 0 0 1 12 0z"/>
+   <path d="M5 50 l25-6 a22 22 0 0 1 0 12z"/>
+  </g></svg>`;
+  for(let i=0;i<N;i++){
+    const row=document.createElement('div');row.className='fanRow';
+    row.innerHTML=`<label id="lab${i}"></label>
+      <input id="r${i}" type="range" min="0" max="255">
+      <span class="val" id="v${i}"></span>`;
+    sliders.appendChild(row);
+    $("r"+i).addEventListener('input',e=>{
+      applyPWM(i,+e.target.value);
+      clearTimeout(timer);timer=setTimeout(sendBulk,80);
+    });
+    // icons
+    const d=document.createElement('div');
+    d.id="f"+i; d.className='fanIcon'; d.innerHTML=svg;
+    d.addEventListener('click',()=>focusSlider(i));
+    d.addEventListener('pointerdown',startDrag);
+    $("canvas").appendChild(d);
+  }
+
+  $("editBtn").onclick=enableEdit;
+  $("lockBtn").onclick=lockLayout;
+  $("boostSave").onclick=saveBoost;
+  $("rebootBtn").onclick=()=>confirm('Reboot ESP32?')&&fetch('/reboot',{method:'POST'});
+  $("loadPreset").onclick=loadPreset;
+  $("savePreset").onclick=savePreset;
+  $("delPreset").onclick=delPreset;
+  $("editLabels").onclick=editLabels;
+}
+
+/* ─────────────── FOCUS HIGHLIGHT ─────────────── */
+function focusSlider(i){
+  document.querySelectorAll('.hl').forEach(el=>el.classList.remove('hl'));
+  $("r"+i).classList.add('hl');
+  $("r"+i).scrollIntoView({block:'center',behavior:'smooth'});
+}
+
+/* ─────────────── DRAGGING ─────────────── */
+function enableEdit(){
+  editMode=true;$("editBtn").classList.add('locked');
+  $("lockBtn").classList.remove('locked');
+  document.body.style.cursor='move';
+}
+function lockLayout(){
+  editMode=false;$("editBtn").classList.remove('locked');
+  $("lockBtn").classList.add('locked');
+  document.body.style.cursor='';
+  // save
+  fetch('/layout',{method:'POST',headers:{'content-type':'application/json'},
+    body:JSON.stringify({layout})});
+}
+function startDrag(e){
+  if(!editMode) return;
+  dragEl=e.currentTarget;
+  const rect=dragEl.getBoundingClientRect();
+  offX=e.clientX-rect.left; offY=e.clientY-rect.top;
+  document.addEventListener('pointermove',onDrag);
+  document.addEventListener('pointerup',endDrag);
+}
+function onDrag(e){
+  const cvs=$("canvas").getBoundingClientRect();
+  let x=e.clientX-cvs.left-offX, y=e.clientY-cvs.top-offY;
+  x=Math.max(0,Math.min(cvs.width-dragEl.offsetWidth,x));
+  y=Math.max(0,Math.min(cvs.height-dragEl.offsetHeight,y));
+  const xp=(x/cvs.width)*100, yp=(y/cvs.height)*100;
+  dragEl.style.left=xp+'%'; dragEl.style.top=yp+'%';
+  layout[+dragEl.id.slice(1)]={x:xp,y:yp};
+}
+function endDrag(){
+  document.removeEventListener('pointermove',onDrag);
+  document.removeEventListener('pointerup',endDrag); dragEl=null;
+}
+
+/* ─────────────── CONFIG HANDLERS ─────────────── */
+async function loadConfig(){
+  const cfg=await fetch('/config').then(r=>r.json());
+  labels=cfg.labels??[]; presets=cfg.presets??{}; layout=cfg.layout??[];
+  labels.forEach((t,i)=>{$("lab"+i).textContent=t;});
+  layout.forEach((p,i)=>{const ic=$("f"+i);ic.style.left=p.x+'%';ic.style.top=p.y+'%';});
+  // presets dropdown
+  const sel=$("presetSel"); sel.innerHTML='';
+  Object.keys(presets).forEach(n=>{
+    const o=document.createElement('option');o.textContent=n;sel.appendChild(o);});
+}
+async function refresh(){
+  const st=await fetch('/status').then(r=>r.json());
+  const inf=await fetch('/info').then(r=>r.json());
+  $("info").textContent=`FW ${inf.fw} | ${inf.ip} | ${inf.upt}s`;
+  $("hdr").textContent=`FanCtl ${inf.ip}`;
+  $("boostSec").value=inf.boost;
+  st.forEach((f,i)=>{applyPWM(i,f.pwm);});
+}
+function saveBoost(){
+  fetch('/boost',{method:'POST',headers:{'content-type':'application/json'},
+    body:JSON.stringify({seconds:+$("boostSec").value})});
+}
+function loadPreset(){
+  const n=$("presetSel").value; if(!n||!presets[n])return;
+  fetch('/preset/apply?name='+encodeURIComponent(n),{method:'POST'}).then(refresh);
+}
+function savePreset(){
+  const n=$("presetName").value.trim(); if(!n)return alert('name?');
+  const arr=[...Array(N)].map((_,i)=>+$("r"+i).value);
+  fetch('/preset',{method:'POST',headers:{'content-type':'application/json'},
+    body:JSON.stringify({name:n,pwms:arr})}).then(()=>loadConfig());
+}
+function delPreset(){
+  const n=$("presetSel").value; if(!n||!presets[n])return;
+  if(!confirm('Delete '+n+'?')) return;
+  fetch('/preset/'+encodeURIComponent(n),{method:'DELETE'}).then(()=>loadConfig());
+}
+async function editLabels(){
+  for(let i=0;i<N;i++){
+    const t=prompt('Label '+i, labels[i]||'')||labels[i];
+    labels[i]=t;
+  }
+  await fetch('/labels',{method:'POST',headers:{'content-type':'application/json'},
+    body:JSON.stringify({labels})});
+  loadConfig();
+}
+
+/* ─────────────── MAIN ─────────────── */
+(async()=>{
+  build();
+  await loadConfig();
+  await refresh();
+  setInterval(refresh,2000);
+})();


### PR DESCRIPTION
## Summary
- implement sensor polling and fan regulation rules
- expose `/temp_sources` and `/rules` API endpoints
- serve `static/index.html` and move client JS to `static/main.js`
- allow configuring fan rules in the web UI
- limit monitor targets to `Core Average` and `GPU Core`
- fix Boost field id

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6848750af3e48332ad12d15803b05050